### PR TITLE
Improve error handling and memory safety for windows implementation.

### DIFF
--- a/quick_blue_windows/windows/quick_blue_windows_plugin.cpp
+++ b/quick_blue_windows/windows/quick_blue_windows_plugin.cpp
@@ -74,39 +74,41 @@ std::string to_uuidstr(winrt::guid guid) {
 
 static IAsyncOperation<GattDeviceServicesResult> GetGattServicesAsync(BluetoothLEDevice device) {
   try {
-    return co_await device.GetGattServicesAsync();
+    auto serviceResult = co_await device.GetGattServicesAsync();
+    co_return serviceResult;
   } catch(winrt::hresult_error const& ex) {
     OutputDebugString((L"GetGattServicesAsync " + ex.message() + L"\n").c_str());
-    return nullptr;
+    co_return nullptr;
   }
 }
 
 static IAsyncOperation<GattCharacteristicsResult> GetCharacteristicsAsync(GattDeviceService service) {
   try {
-    return co_await service.GetCharacteristicsAsync();
+    auto characteristicResult = co_await service.GetCharacteristicsAsync();
+    co_return characteristicResult;
   } catch(winrt::hresult_error const& ex) {
     OutputDebugString((L"GetCharacteristicsAsync " + ex.message() + L"\n").c_str());
-    return nullptr;
+    co_return nullptr;
   }
 }
 
 static IAsyncOperation<BluetoothLEDevice> FromBluetoothAddressAsync(uint64_t address) {
   try {
     auto device = co_await BluetoothLEDevice::FromBluetoothAddressAsync(address);
-    return device;
+    co_return device;
   } catch(winrt::hresult_error const& ex) {
     OutputDebugString((L"FromBluetoothAddressAsync " + ex.message() + L"\n").c_str());
-    return nullptr;
+    co_return nullptr;
   }
 }
 
 static IAsyncOperation<GattReadResult> ReadCharacteristicValueAsync(GattCharacteristic characteristic) {
   try {
-    auto readResult = characteristic.ReadValueAsync();
-    return readResult;
+    auto readResult = co_await characteristic.ReadValueAsync();
+    co_return readResult;
   } catch(winrt::hresult_error const& ex) {
     OutputDebugString((L"ReadCharacteristicValueAsync " + ex.message() + L"\n").c_str());
-    return nullptr;
+    co_return nullptr;
   }
 }
 


### PR DESCRIPTION
Each of the WinRT methods can throw exceptions if operations fail. This PR puts small wrappers around most method invocations that will catch the exceptions and produce nullptrs instead.

This also adds some extra logic checks around things which may or may not exist. Like discovery of services does not guarantee you find the service you want.

Lastly it switches the agents to shared_ptrs. This was outstanding async methods do not access invalid memory. This handling could be improved further.