### PR TITLE
Async methods and error stack traces, to reduce crashing and help debugging

### DIFF
--- a/quick_blue/lib/quick_blue.dart
+++ b/quick_blue/lib/quick_blue.dart
@@ -49,24 +49,24 @@ class QuickBlue {
   static Future<bool> isBluetoothAvailable() =>
       _platform.isBluetoothAvailable();
 
-  static void startScan() => _platform.startScan();
+  static Future<void> startScan() => _platform.startScan();
 
-  static void stopScan() => _platform.stopScan();
+  static Future<void> stopScan() => _platform.stopScan();
 
   static Stream<BlueScanResult> get scanResultStream {
     return _platform.scanResultStream
       .map((item) => BlueScanResult.fromMap(item));
   }
 
-  static void connect(String deviceId) => _platform.connect(deviceId);
+  static Future<void> connect(String deviceId) => _platform.connect(deviceId);
 
-  static void disconnect(String deviceId) => _platform.disconnect(deviceId);
+  static Future<void> disconnect(String deviceId) => _platform.disconnect(deviceId);
 
   static void setConnectionHandler(OnConnectionChanged? onConnectionChanged) {
     _platform.onConnectionChanged = onConnectionChanged;
   }
 
-  static void discoverServices(String deviceId) => _platform.discoverServices(deviceId);
+  static Future<void> discoverServices(String deviceId) => _platform.discoverServices(deviceId);
 
   static void setServiceHandler(OnServiceDiscovered? onServiceDiscovered) {
     _platform.onServiceDiscovered = onServiceDiscovered;

--- a/quick_blue_linux/lib/quick_blue_linux.dart
+++ b/quick_blue_linux/lib/quick_blue_linux.dart
@@ -45,20 +45,21 @@ class QuickBlueLinux extends QuickBluePlatform {
   }
 
   @override
-  void startScan() async {
+  Future<void> startScan() async {
     await _ensureInitialized();
     _log('startScan invoke success');
 
-    _activeAdapter!.startDiscovery();
+    final ret = _activeAdapter!.startDiscovery();
     _client.devices.forEach(_onDeviceAdd);
+    return ret;
   }
 
   @override
-  void stopScan() async {
+  Future<void> stopScan() async {
     await _ensureInitialized();
     _log('stopScan invoke success');
 
-    _activeAdapter!.stopDiscovery();
+    return _activeAdapter!.stopDiscovery();
   }
 
   // FIXME Close
@@ -77,19 +78,19 @@ class QuickBlueLinux extends QuickBluePlatform {
   }
 
   @override
-  void connect(String deviceId) {
+  Future<void> connect(String deviceId) {
     // TODO: implement connect
     throw UnimplementedError();
   }
 
   @override
-  void disconnect(String deviceId) {
+  Future<void> disconnect(String deviceId) {
     // TODO: implement disconnect
     throw UnimplementedError();
   }
 
   @override
-  void discoverServices(String deviceId) {
+  Future<void> discoverServices(String deviceId) {
     // TODO: implement discoverServices
     throw UnimplementedError();
   }

--- a/quick_blue_platform_interface/lib/method_channel_quick_blue.dart
+++ b/quick_blue_platform_interface/lib/method_channel_quick_blue.dart
@@ -28,19 +28,18 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
 
   @override
   Future<bool> isBluetoothAvailable() async {
-    bool result = await _method.invokeMethod('isBluetoothAvailable');
-    return result;
+    return await _method.invokeMethod('isBluetoothAvailable');
   }
 
   @override
-  void startScan() {
-    _method.invokeMethod('startScan')
+  Future<void> startScan() {
+    return _method.invokeMethod('startScan')
         .then((_) => print('startScan invokeMethod success'));
   }
 
   @override
-  void stopScan() {
-    _method.invokeMethod('stopScan')
+  Future<void> stopScan() {
+    return _method.invokeMethod('stopScan')
         .then((_) => print('stopScan invokeMethod success'));
   }
 
@@ -50,22 +49,22 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
   Stream<dynamic> get scanResultStream => _scanResultStream;
 
   @override
-  void connect(String deviceId) {
-    _method.invokeMethod('connect', {
+  Future<void> connect(String deviceId) {
+    return _method.invokeMethod('connect', {
       'deviceId': deviceId,
     }).then((_) => _log('connect invokeMethod success'));
   }
 
   @override
-  void disconnect(String deviceId) {
-    _method.invokeMethod('disconnect', {
+  Future<void> disconnect(String deviceId) {
+    return _method.invokeMethod('disconnect', {
       'deviceId': deviceId,
     }).then((_) => _log('disconnect invokeMethod success'));
   }
 
   @override
-  void discoverServices(String deviceId) {
-    _method.invokeMethod('discoverServices', {
+  Future<void> discoverServices(String deviceId) {
+    return _method.invokeMethod('discoverServices', {
       'deviceId': deviceId,
     }).then((_) => _log('discoverServices invokeMethod success'));
   }
@@ -96,7 +95,7 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
 
   @override
   Future<void> setNotifiable(String deviceId, String service, String characteristic, BleInputProperty bleInputProperty) async {
-    _method.invokeMethod('setNotifiable', {
+    return _method.invokeMethod('setNotifiable', {
       'deviceId': deviceId,
       'service': service,
       'characteristic': characteristic,
@@ -106,7 +105,7 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
 
   @override
   Future<void> readValue(String deviceId, String service, String characteristic) async {
-    _method.invokeMethod('readValue', {
+    return _method.invokeMethod('readValue', {
       'deviceId': deviceId,
       'service': service,
       'characteristic': characteristic,
@@ -115,7 +114,7 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
 
   @override
   Future<void> writeValue(String deviceId, String service, String characteristic, Uint8List value, BleOutputProperty bleOutputProperty) async {
-    _method.invokeMethod('writeValue', {
+    return _method.invokeMethod('writeValue', {
       'deviceId': deviceId,
       'service': service,
       'characteristic': characteristic,
@@ -137,7 +136,9 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
     _method.invokeMethod('requestMtu', {
       'deviceId': deviceId,
       'expectedMtu': expectedMtu,
-    }).then((_) => _log('requestMtu invokeMethod success'));
+    }).then((_) => _log('requestMtu invokeMethod success')).catchError((e) {
+      _log("requestMtu error: $e"); //TODO Return future that errors if this errors
+    });
     return await _mtuConfigController.stream.first;
   }
 }

--- a/quick_blue_platform_interface/lib/quick_blue_platform_interface.dart
+++ b/quick_blue_platform_interface/lib/quick_blue_platform_interface.dart
@@ -37,19 +37,19 @@ abstract class QuickBluePlatform extends PlatformInterface {
 
   Future<bool> isBluetoothAvailable();
 
-  void startScan();
+  Future<void> startScan();
 
-  void stopScan();
+  Future<void> stopScan();
 
   Stream<dynamic> get scanResultStream;
 
-  void connect(String deviceId);
+  Future<void> connect(String deviceId);
 
-  void disconnect(String deviceId);
+  Future<void> disconnect(String deviceId);
 
   OnConnectionChanged? onConnectionChanged;
 
-  void discoverServices(String deviceId);
+  Future<void> discoverServices(String deviceId);
 
   OnServiceDiscovered? onServiceDiscovered;
 


### PR DESCRIPTION
As it was, any of several different mistakes (such as not discovering services before trying to read a characteristic) would cause a PlatformException to be thrown in an unawaited Future, crashing the whole app.  I've converted all such methods as I've found from `void` to async `Future<void>`, enabling the user to await their completion or add a `catchError`.  I also added a stack trace to a number of otherwise more opaque errors.