### PR TITLE
Xcode warnings

### DIFF
--- a/quick_blue/ios/Classes/SwiftQuickBluePlugin.swift
+++ b/quick_blue/ios/Classes/SwiftQuickBluePlugin.swift
@@ -54,6 +54,8 @@ public class SwiftQuickBluePlugin: NSObject, FlutterPlugin {
 
   private var scanResultSink: FlutterEventSink?
   private var messageConnector: FlutterBasicMessageChannel!
+  
+  private var nilDescription: String { "nil" }
 
   override init() {
     super.init()
@@ -161,7 +163,7 @@ extension SwiftQuickBluePlugin: CBCentralManagerDelegate {
   }
 
   public func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
-    print("centralManager:didDiscoverPeripheral \(peripheral.name) \(peripheral.uuid.uuidString)")
+    print("centralManager:didDiscoverPeripheral \(peripheral.name ?? nilDescription) \(peripheral.uuid.uuidString)")
     discoveredPeripherals[peripheral.uuid.uuidString] = peripheral
 
     let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
@@ -182,7 +184,7 @@ extension SwiftQuickBluePlugin: CBCentralManagerDelegate {
   }
   
   public func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
-    print("centralManager:didDisconnectPeripheral: \(peripheral.uuid.uuidString) error: \(error)")
+    print("centralManager:didDisconnectPeripheral: \(peripheral.uuid.uuidString) error: \(error?.localizedDescription ?? nilDescription)")
     messageConnector.sendMessage([
       "deviceId": peripheral.uuid.uuidString,
       "ConnectionState": "disconnected",
@@ -216,7 +218,7 @@ extension SwiftQuickBluePlugin: FlutterStreamHandler {
 
 extension SwiftQuickBluePlugin: CBPeripheralDelegate {
   public func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-    print("peripheral: \(peripheral.uuid.uuidString) didDiscoverServices: \(error)")
+    print("peripheral: \(peripheral.uuid.uuidString) didDiscoverServices: \(error?.localizedDescription ?? nilDescription)")
     for service in peripheral.services! {
       peripheral.discoverCharacteristics(nil, for: service)
     }
@@ -235,11 +237,13 @@ extension SwiftQuickBluePlugin: CBPeripheralDelegate {
   }
     
   public func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
-    print("peripheral:didWriteValueForCharacteristic \(characteristic.uuid.uuidStr) \(characteristic.value as? NSData) error: \(error)")
+    let value = characteristic.value as? NSData
+    print("peripheral:didWriteValueForCharacteristic \(characteristic.uuid.uuidStr) \(value?.description ?? nilDescription) error: \(error?.localizedDescription ?? nilDescription)")
   }
     
   public func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
-    print("peripheral:didUpdateValueForForCharacteristic \(characteristic.uuid) \(characteristic.value as! NSData) error: \(error)")
+    let value = characteristic.value as? NSData
+    print("peripheral:didUpdateValueForForCharacteristic \(characteristic.uuid) \(value?.description ?? nilDescription) error: \(error?.localizedDescription ?? nilDescription)")
     self.messageConnector.sendMessage([
       "deviceId": peripheral.uuid.uuidString,
       "characteristicValue": [

--- a/quick_blue_example/lib/PeripheralDetailPage.dart
+++ b/quick_blue_example/lib/PeripheralDetailPage.dart
@@ -74,13 +74,13 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: <Widget>[
-              RaisedButton(
+              ElevatedButton(
                 child: Text('connect'),
                 onPressed: () {
                   QuickBlue.connect(widget.deviceId);
                 },
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: Text('disconnect'),
                 onPressed: () {
                   QuickBlue.disconnect(widget.deviceId);
@@ -91,7 +91,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: <Widget>[
-              RaisedButton(
+              ElevatedButton(
                 child: Text('discoverServices'),
                 onPressed: () {
                   QuickBlue.discoverServices(widget.deviceId);
@@ -99,7 +99,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
               ),
             ],
           ),
-          RaisedButton(
+          ElevatedButton(
             child: Text('setNotifiable'),
             onPressed: () {
               QuickBlue.setNotifiable(
@@ -125,7 +125,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
               labelText: 'Binary code',
             ),
           ),
-          RaisedButton(
+          ElevatedButton(
             child: Text('send'),
             onPressed: () {
               var value = Uint8List.fromList(hex.decode(binaryCode.text));
@@ -134,7 +134,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                   value, BleOutputProperty.withResponse);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             child: Text('readValue battery'),
             onPressed: () async {
               await QuickBlue.readValue(
@@ -143,7 +143,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                   GSS_CHAR__BATTERY_LEVEL);
             },
           ),
-          RaisedButton(
+          ElevatedButton(
             child: Text('requestMtu'),
             onPressed: () async {
               var mtu = await QuickBlue.requestMtu(widget.deviceId, WOODEMI_MTU_WUART);

--- a/quick_blue_example/lib/main.dart
+++ b/quick_blue_example/lib/main.dart
@@ -71,13 +71,13 @@ class _MyAppState extends State<MyApp> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: <Widget>[
-        RaisedButton(
+        ElevatedButton(
           child: Text('startScan'),
           onPressed: () {
             QuickBlue.startScan();
           },
         ),
-        RaisedButton(
+        ElevatedButton(
           child: Text('stopScan'),
           onPressed: () {
             QuickBlue.stopScan();

--- a/quick_blue_macos/macos/Classes/QuickBlueMacosPlugin.swift
+++ b/quick_blue_macos/macos/Classes/QuickBlueMacosPlugin.swift
@@ -54,6 +54,8 @@ public class QuickBlueMacosPlugin: NSObject, FlutterPlugin {
 
   private var scanResultSink: FlutterEventSink?
   private var messageConnector: FlutterBasicMessageChannel!
+    
+  private var nilDescription: String { "nil" }
 
   override init() {
     super.init()
@@ -161,7 +163,7 @@ extension QuickBlueMacosPlugin: CBCentralManagerDelegate {
   }
 
   public func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
-    print("centralManager:didDiscoverPeripheral \(peripheral.name) \(peripheral.uuid.uuidString)")
+    print("centralManager:didDiscoverPeripheral \(peripheral.name ?? nilDescription) \(peripheral.uuid.uuidString)")
     discoveredPeripherals[peripheral.uuid.uuidString] = peripheral
 
     let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
@@ -182,7 +184,7 @@ extension QuickBlueMacosPlugin: CBCentralManagerDelegate {
   }
     
   public func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
-    print("centralManager:didDisconnectPeripheral: \(peripheral.uuid.uuidString) error: \(error)")
+      print("centralManager:didDisconnectPeripheral: \(peripheral.uuid.uuidString) error: \(error?.localizedDescription ?? nilDescription)")
     messageConnector.sendMessage([
       "deviceId": peripheral.uuid.uuidString,
       "ConnectionState": "disconnected",
@@ -216,7 +218,7 @@ extension QuickBlueMacosPlugin: FlutterStreamHandler {
 
 extension QuickBlueMacosPlugin: CBPeripheralDelegate {
   public func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-    print("peripheral: \(peripheral.uuid.uuidString) didDiscoverServices: \(error)")
+      print("peripheral: \(peripheral.uuid.uuidString) didDiscoverServices: \(error?.localizedDescription ?? nilDescription)")
     for service in peripheral.services! {
       peripheral.discoverCharacteristics(nil, for: service)
     }
@@ -235,11 +237,13 @@ extension QuickBlueMacosPlugin: CBPeripheralDelegate {
   }
 
   public func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
-    print("peripheral:didWriteValueForCharacteristic \(characteristic.uuid.uuidStr) \(characteristic.value as? NSData) error: \(error)")
+      let value = characteristic.value as? NSData
+      print("peripheral:didWriteValueForCharacteristic \(characteristic.uuid.uuidStr) \(value?.description ?? nilDescription) error: \(error?.localizedDescription ?? nilDescription)")
   }
 
   public func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
-    print("peripheral:didUpdateValueForForCharacteristic \(characteristic.uuid) \(characteristic.value as! NSData) error: \(error)")
+    let value = characteristic.value as? NSData
+    print("peripheral:didUpdateValueForForCharacteristic \(characteristic.uuid) \(value?.description ?? nilDescription) error: \(error?.localizedDescription ?? nilDescription)")
     self.messageConnector.sendMessage([
       "deviceId": peripheral.uuid.uuidString,
       "characteristicValue": [


### PR DESCRIPTION
This PR resolve all the warnings rised by Xcode caused by printing object that can be null
```
/opt/flutter/.pub-cache/hosted/pub.dartlang.org/quick_blue_macos-0.3.1+2/macos/Classes/QuickBlueMacosPlugin.swift:164:51: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?
    print("centralManager:didDiscoverPeripheral \(peripheral.name) \(peripheral.uuid.uuidString)")
                                                  ^~~~~~~~~~~~~~~
    print("centralManager:didDiscoverPeripheral \(peripheral.name) \(peripheral.uuid.uuidString)")
                                                  ~~~~~~~~~~~^~~~
                                                  String(describing:  )
    print("centralManager:didDiscoverPeripheral \(peripheral.name) \(peripheral.uuid.uuidString)")
                                                  ~~~~~~~~~~~^~~~
                                                                  ?? <#default value#>
/opt/flutter/.pub-cache/hosted/pub.dartlang.org/quick_blue_macos-0.3.1+2/macos/Classes/QuickBlueMacosPlugin.swift:185:91: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?

    print("centralManager:didDisconnectPeripheral: \(peripheral.uuid.uuidString) error: \(error)")
                                                                                          ^~~~~
    print("centralManager:didDisconnectPeripheral: \(peripheral.uuid.uuidString) error: \(error)")
                                                                                          ^~~~~
                                                                                          String(describing:  )
    print("centralManager:didDisconnectPeripheral: \(peripheral.uuid.uuidString) error: \(error)")
                                                                                          ^~~~~
                                                                                          ?? <#default value#>
/opt/flutter/.pub-cache/hosted/pub.dartlang.org/quick_blue_macos-0.3.1+2/macos/Classes/QuickBlueMacosPlugin.swift:219:77: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?
    print("peripheral: \(peripheral.uuid.uuidString) didDiscoverServices: \(error)")
                                                                            ^~~~~
    print("peripheral: \(peripheral.uuid.uuidString) didDiscoverServices: \(error)")
                                                                            ^~~~~
                                                                            String(describing:  )
    print("peripheral: \(peripheral.uuid.uuidString) didDiscoverServices: \(error)")
                                                                            ^~~~~
                                                                                  ?? <#default value#>
/opt/flutter/.pub-cache/hosted/pub.dartlang.org/quick_blue_macos-0.3.1+2/macos/Classes/QuickBlueMacosPlugin.swift:237:87: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?
    print("peripheral:didWriteValueForCharacteristic \(characteristic.uuid.uuidStr) \(characteristic.value as? NSData) error: \(error)")

                                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    print("peripheral:didWriteValueForCharacteristic \(characteristic.uuid.uuidStr) \(characteristic.value as? NSData) error: \(error)")
                                                                                      ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
```