### PR TITLE
Fixing 127 issue

### DIFF
--- a/quick_blue_windows/windows/quick_blue_windows_plugin.cpp
+++ b/quick_blue_windows/windows/quick_blue_windows_plugin.cpp
@@ -212,7 +212,9 @@ QuickBlueWindowsPlugin::~QuickBlueWindowsPlugin() {}
 
 winrt::fire_and_forget QuickBlueWindowsPlugin::InitializeAsync() {
   auto bluetoothAdapter = co_await BluetoothAdapter::GetDefaultAsync();
-  bluetoothRadio = co_await bluetoothAdapter.GetRadioAsync();
+  if (bluetoothAdapter) {
+    bluetoothRadio = co_await bluetoothAdapter.GetRadioAsync();
+  }
 }
 
 void QuickBlueWindowsPlugin::HandleMethodCall(


### PR DESCRIPTION
Issue #127: The Flutter application cannot start if it has this plugin and there is no bluetooth dongle inserted into the Windows computer.