### PR TITLE
Change the type of characteristicIds to nullable

### DIFF
--- a/quick_blue_platform_interface/lib/method_channel_quick_blue.dart
+++ b/quick_blue_platform_interface/lib/method_channel_quick_blue.dart
@@ -80,7 +80,7 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
       if (message['ServiceState'] == 'discovered') {
         String deviceId = message['deviceId'];
         String service = message['service'];
-        List<String> characteristics = (message['characteristics'] as List).cast();
+        List<String>? characteristics = message['characteristics'];
         onServiceDiscovered?.call(deviceId, service, characteristics);
       }
     } else if (message['characteristicValue'] != null) {

--- a/quick_blue_platform_interface/lib/quick_blue_platform_interface.dart
+++ b/quick_blue_platform_interface/lib/quick_blue_platform_interface.dart
@@ -15,7 +15,7 @@ typedef QuickLogger = Logger;
 typedef OnConnectionChanged = void Function(
     String deviceId, BlueConnectionState state);
 
-typedef OnServiceDiscovered = void Function(String deviceId, String serviceId, List<String> characteristicIds);
+typedef OnServiceDiscovered = void Function(String deviceId, String serviceId, List<String>? characteristicIds);
 
 typedef OnValueChanged = void Function(String deviceId, String characteristicId, Uint8List value);
 


### PR DESCRIPTION
On some devices, e.g. DISTO X3 0650740, characteristicIds may be null, leading to the error:`type 'Null' is not a subtype of type 'List<dynamic>' in type cast`